### PR TITLE
feat(wishlist): enrich API with item metadata and product ID resolution

### DIFF
--- a/common/middleware/middleware.go
+++ b/common/middleware/middleware.go
@@ -201,7 +201,7 @@ func CORS() gin.HandlerFunc {
 			Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
 		c.Writer.Header().
 			Set("Access-Control-Allow-Headers",
-				"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-Seller-ID, X-Correlation-ID, Idempotency-Key")
+				"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-Seller-ID, X-Correlation-ID, X-Device-ID, Idempotency-Key")
 
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(http.StatusNoContent)

--- a/product/container.go
+++ b/product/container.go
@@ -24,7 +24,7 @@ func NewContainer(router *gin.Engine) *common.Container {
 }
 
 /* Register all modules (Categories, Products, Attributes, etc.) */
-// TODO: We havve to use cache for most of this APIs because this sevice is very frequently
+// TODO: We have to use cache for most of this APIs because this sevice is very frequently
 // use service by users so it is very important to use cache for this service and create this sevice by AI so
 // as per my observation AI did not cache the data properly
 

--- a/product/factory/singleton/service_factory.go
+++ b/product/factory/singleton/service_factory.go
@@ -67,6 +67,8 @@ func (f *ServiceFactory) initialize() {
 		f.wishlistItemService = service.NewWishlistItemService(
 			f.repoFactory.GetWishlistItemRepository(),
 			f.repoFactory.GetWishlistRepository(),
+			variantRepo,
+			productRepo,
 		)
 
 		// Initialize ProductFileGateway early — both VariantMediaService and
@@ -145,7 +147,7 @@ func (f *ServiceFactory) initialize() {
 			productFileGateway,
 		)
 
-		// Initialize ProductQueryService with VariantQueryService and media service
+		// Initialize ProductQueryService with VariantQueryService, media service, and wishlist service
 		f.productQueryService = service.NewProductQueryService(
 			productRepo,
 			f.variantQueryService,
@@ -154,13 +156,15 @@ func (f *ServiceFactory) initialize() {
 			f.packageOptionService,
 			f.productOptionService,
 			f.productMediaService,
+			f.wishlistItemService,
 		)
 
-		// Initialize WishlistService (needs ProductQueryService for product details)
+		// Initialize WishlistService (needs ProductQueryService + VariantQueryService for product details)
 		f.wishlistService = service.NewWishlistService(
 			f.repoFactory.GetWishlistRepository(),
 			f.repoFactory.GetWishlistItemRepository(),
 			f.productQueryService,
+			f.variantQueryService,
 		)
 
 		// Initialize RecentlyViewedService with repository and ProductQueryService.

--- a/product/model/product_model.go
+++ b/product/model/product_model.go
@@ -110,7 +110,8 @@ type ProductResponse struct {
 	AllowPurchase  bool            `json:"allowPurchase"`            // At least one variant allows purchase
 	IsPopular      bool            `json:"isPopular"`                // At least one variant is popular
 	VariantPreview *VariantPreview `json:"variantPreview,omitempty"` // Option preview for listings
-	IsWishlisted   bool            `json:"isWishlisted"`             // User-specific: true if any variant is in user's wishlist
+	IsWishlisted   bool               `json:"isWishlisted"`               // User-specific: true if any variant is in user's wishlist
+	WishlistItems  []WishlistItemInfo `json:"wishlistItems,omitempty"` // Simple products only: wishlist item IDs for the default placeholder variant
 
 	// Detail product info (for get product by ID)
 	Attributes     []ProductAttributeResponse    `json:"attributes,omitempty"`

--- a/product/model/variant_model.go
+++ b/product/model/variant_model.go
@@ -19,6 +19,13 @@ type ProductBasicInfo struct {
 	CategoryID uint   `json:"categoryId,omitempty"`
 }
 
+// WishlistItemInfo contains the minimum info the FE needs to remove a wishlist item.
+// variantId is intentionally absent — the parent VariantDetailResponse already has id.
+type WishlistItemInfo struct {
+	WishlistItemID uint `json:"wishlistItemId"`
+	WishlistID     uint `json:"wishlistId"`
+}
+
 // VariantDetailResponse represents detailed variant information
 type VariantDetailResponse struct {
 	ID              uint                    `json:"id"`
@@ -30,6 +37,7 @@ type VariantDetailResponse struct {
 	IsPopular       bool                    `json:"isPopular"`
 	IsDefault       bool                    `json:"isDefault"`
 	IsWishlisted    bool                    `json:"isWishlisted"`
+	WishlistItems   []WishlistItemInfo      `json:"wishlistItems,omitempty"`
 	SelectedOptions []VariantOptionResponse `json:"selectedOptions"`
 	// Media is always a JSON array (never null). Items ordered by display_order ASC, id ASC.
 	// Items whose file data cannot be resolved are silently omitted.

--- a/product/model/wishlist_model.go
+++ b/product/model/wishlist_model.go
@@ -1,6 +1,10 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"ecommerce-be/common"
+)
 
 // ============================================================================
 // Wishlist Management - Request Models
@@ -36,14 +40,23 @@ type WishlistsResponse struct {
 	Wishlists []WishlistResponse `json:"wishlists"`
 }
 
+// WishlistProductItem represents a single wishlist item with the resolved product
+type WishlistProductItem struct {
+	WishlistItemID uint            `json:"wishlistItemId"` // ID of the wishlist item (for delete/move)
+	VariantID      uint            `json:"variantId"`      // The specific variant that was wishlisted
+	AddedAt        time.Time       `json:"addedAt"`        // When the item was added to the wishlist
+	Product        ProductResponse `json:"product"`        // Full resolved product with variants
+}
+
 // WishlistDetailResponse represents the response for getting a wishlist with products
-// Uses ProductsResponse for full product details with pagination support
+// Uses WishlistProductItem for per-item metadata with full product details
+// Pagination is top-level (not nested inside a sub-object)
 type WishlistDetailResponse struct {
-	ID        uint             `json:"id"`
-	Name      string           `json:"name"`
-	IsDefault bool             `json:"isDefault"`
-	ItemCount int              `json:"itemCount"` // Total items in wishlist (not paginated count)
-	Products  ProductsResponse `json:"products"`  // Paginated products with full details
-	CreatedAt time.Time        `json:"createdAt"`
-	UpdatedAt time.Time        `json:"updatedAt"`
+	ID         uint                      `json:"id"`
+	Name       string                    `json:"name"`
+	IsDefault  bool                      `json:"isDefault"`
+	Items      []WishlistProductItem     `json:"items"`      // Paginated items with product details
+	Pagination common.PaginationResponse `json:"pagination"` // Pagination metadata
+	CreatedAt  time.Time                 `json:"createdAt"`
+	UpdatedAt  time.Time                 `json:"updatedAt"`
 }

--- a/product/repository/wishlist_item_repository.go
+++ b/product/repository/wishlist_item_repository.go
@@ -47,6 +47,14 @@ type WishlistItemRepository interface {
 		userID uint,
 	) (map[uint]bool, error)
 
+	// FindWishlistItemsByVariantIDsAndUserID returns full wishlist item entities for given
+	// variant IDs scoped to a specific user (across all their wishlists).
+	FindWishlistItemsByVariantIDsAndUserID(
+		ctx context.Context,
+		variantIDs []uint,
+		userID uint,
+	) ([]entity.WishlistItem, error)
+
 	// CountByWishlistID counts items in a wishlist
 	CountByWishlistID(ctx context.Context, wishlistID uint) (int64, error)
 
@@ -60,6 +68,14 @@ type WishlistItemRepository interface {
 		wishlistID uint,
 		page, limit int,
 	) ([]uint, int64, error)
+
+	// FindWishlistItemsByWishlistID finds all wishlist items for a wishlist with pagination
+	// Returns full WishlistItem entities (with ID, variant_id, created_at) ordered by created_at DESC
+	FindWishlistItemsByWishlistID(
+		ctx context.Context,
+		wishlistID uint,
+		page, limit int,
+	) ([]entity.WishlistItem, int64, error)
 }
 
 // ============================================================================
@@ -196,6 +212,30 @@ func (r *wishlistItemRepositoryImpl) AreVariantsInUserWishlist(
 	return result, nil
 }
 
+// FindWishlistItemsByVariantIDsAndUserID returns full wishlist item entities for given
+// variant IDs scoped to a specific user (across all their wishlists).
+func (r *wishlistItemRepositoryImpl) FindWishlistItemsByVariantIDsAndUserID(
+	ctx context.Context,
+	variantIDs []uint,
+	userID uint,
+) ([]entity.WishlistItem, error) {
+	if len(variantIDs) == 0 {
+		return []entity.WishlistItem{}, nil
+	}
+	var items []entity.WishlistItem
+	err := r.getDB().WithContext(ctx).Raw(`
+		SELECT wi.id, wi.wishlist_id, wi.variant_id, wi.created_at, wi.updated_at
+		FROM wishlist_item wi
+		INNER JOIN wishlist w ON w.id = wi.wishlist_id
+		WHERE wi.variant_id IN (?)
+		  AND w.user_id = ?
+	`, variantIDs, userID).Scan(&items).Error
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 // CountByWishlistID counts items in a wishlist
 func (r *wishlistItemRepositoryImpl) CountByWishlistID(
 	ctx context.Context,
@@ -262,4 +302,38 @@ func (r *wishlistItemRepositoryImpl) FindVariantIDsByWishlistID(
 	}
 
 	return variantIDs, total, nil
+}
+
+// FindWishlistItemsByWishlistID finds all wishlist items for a wishlist with pagination
+// Returns full WishlistItem entities (with ID, variant_id, created_at) ordered by created_at DESC
+func (r *wishlistItemRepositoryImpl) FindWishlistItemsByWishlistID(
+	ctx context.Context,
+	wishlistID uint,
+	page, limit int,
+) ([]entity.WishlistItem, int64, error) {
+	var total int64
+	var items []entity.WishlistItem
+
+	// Count total items
+	err := r.getDB().WithContext(ctx).
+		Model(&entity.WishlistItem{}).
+		Where("wishlist_id = ?", wishlistID).
+		Count(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Get wishlist items with pagination (returns ID, variant_id, created_at)
+	offset := (page - 1) * limit
+	err = r.getDB().WithContext(ctx).
+		Where("wishlist_id = ?", wishlistID).
+		Order("created_at DESC").
+		Offset(offset).
+		Limit(limit).
+		Find(&items).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return items, total, nil
 }

--- a/product/service/product_query_service.go
+++ b/product/service/product_query_service.go
@@ -59,6 +59,7 @@ type ProductQueryServiceImpl struct {
 	packageOptionService    PackageOptionService
 	productOptionService    ProductOptionService
 	productMediaService     ProductMediaService
+	wishlistItemService     WishlistItemService
 }
 
 // NewProductQueryService creates a new instance of ProductQueryService
@@ -70,6 +71,7 @@ func NewProductQueryService(
 	packageOptionService PackageOptionService,
 	productOptionService ProductOptionService,
 	productMediaService ProductMediaService,
+	wishlistItemService WishlistItemService,
 ) *ProductQueryServiceImpl {
 	return &ProductQueryServiceImpl{
 		productRepo:             productRepo,
@@ -79,6 +81,7 @@ func NewProductQueryService(
 		packageOptionService:    packageOptionService,
 		productOptionService:    productOptionService,
 		productMediaService:     productMediaService,
+		wishlistItemService:     wishlistItemService,
 	}
 }
 
@@ -127,7 +130,8 @@ func (s *ProductQueryServiceImpl) GetAllProducts(
 // buildProductResponsesWithVariants builds ProductResponse list from products with variant data
 // Performs batch variant aggregation for optimal performance - single query for all products
 // If userID is provided, also checks if products are wishlisted by that user.
-// sellerID is passed to the media gateway for scoped file access; nil means platform-wide.
+// sellerID is passed to the media gateway for scoped file access; nil triggers per-seller
+// batching so that seller-owned files are still resolved correctly.
 func (s *ProductQueryServiceImpl) buildProductResponsesWithVariants(
 	ctx context.Context,
 	products []entity.Product,
@@ -155,8 +159,32 @@ func (s *ProductQueryServiceImpl) buildProductResponsesWithVariants(
 		return nil, err
 	}
 
-	// Batch-load media for all products in a single call (no N+1 on file lookups).
-	mediaByProductID, _ := s.productMediaService.GetMediaForProducts(ctx, productIDs, sellerID)
+	// Batch-load media for all products.
+	// When sellerID is explicitly provided, a single media call suffices.
+	// When sellerID is nil (e.g., wishlist service or cross-seller context), we MUST
+	// group products by seller and make per-seller calls. Otherwise the file gateway
+	// builds a Principal with OwnerType=PLATFORM, which cannot resolve seller-owned files.
+	mediaByProductID := make(map[uint][]model.ProductMediaResponse, len(products))
+	if sellerID != nil {
+		// Single-seller context – one batch call is enough.
+		mediaByProductID, _ = s.productMediaService.GetMediaForProducts(ctx, productIDs, sellerID)
+	} else {
+		// Cross-seller context – group products by SellerID and make per-seller calls.
+		sellerToProductIDs := make(map[uint][]uint)
+		for _, product := range products {
+			sellerToProductIDs[product.SellerID] = append(
+				sellerToProductIDs[product.SellerID],
+				product.ID,
+			)
+		}
+		for sid, pIDs := range sellerToProductIDs {
+			sidCopy := sid
+			perSellerMedia, _ := s.productMediaService.GetMediaForProducts(ctx, pIDs, &sidCopy)
+			for pid, media := range perSellerMedia {
+				mediaByProductID[pid] = media
+			}
+		}
+	}
 
 	// Build response models with variant and media data using factory
 	productsResponse := make([]model.ProductResponse, 0, len(products))
@@ -258,6 +286,39 @@ func (s *ProductQueryServiceImpl) buildDetailedProductResponse(
 	allVariants, err := s.variantQueryService.GetProductVariantsWithOptions(ctx, product.ID, mediaSellerID)
 	if err == nil {
 		response.Variants = productUtils.FilterPublicVariants(allVariants)
+	}
+
+	// Enrich wishlist item IDs if user is authenticated.
+	// Configurable products: attach to each public variant.
+	// Simple products: variants[] is empty (placeholder hidden) — attach at product level.
+	if userID != nil && len(response.Variants) > 0 {
+		variantIDs := make([]uint, len(response.Variants))
+		for i, v := range response.Variants {
+			variantIDs[i] = v.ID
+		}
+		itemsByVariant, err := s.wishlistItemService.GetWishlistItemsByVariantIDs(ctx, variantIDs, *userID)
+		if err == nil {
+			for i := range response.Variants {
+				if items, ok := itemsByVariant[response.Variants[i].ID]; ok {
+					response.Variants[i].WishlistItems = items
+					response.Variants[i].IsWishlisted = true
+				}
+			}
+		}
+	} else if userID != nil && len(allVariants) > 0 {
+		if def := productUtils.FindDefaultVariant(allVariants); def != nil {
+			itemsByVariant, err := s.wishlistItemService.GetWishlistItemsByVariantIDs(
+				ctx,
+				[]uint{def.ID},
+				*userID,
+			)
+			if err == nil {
+				if items, ok := itemsByVariant[def.ID]; ok {
+					response.WishlistItems = items
+					response.IsWishlisted = true
+				}
+			}
+		}
 	}
 
 	// Batch-load media for this product; always set a non-nil slice.

--- a/product/service/wishlist_item_service.go
+++ b/product/service/wishlist_item_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 
 	"gorm.io/gorm"
 
@@ -50,6 +51,14 @@ type WishlistItemService interface {
 		variantIDs []uint,
 		userID uint,
 	) (map[uint]bool, error)
+
+	// GetWishlistItemsByVariantIDs returns wishlist item info for variant IDs.
+	// Returns map of variantID -> []WishlistItemInfo for efficient per-variant enrichment.
+	GetWishlistItemsByVariantIDs(
+		ctx context.Context,
+		variantIDs []uint,
+		userID uint,
+	) (map[uint][]model.WishlistItemInfo, error)
 }
 
 // ============================================================================
@@ -59,21 +68,29 @@ type WishlistItemService interface {
 type wishlistItemServiceImpl struct {
 	wishlistItemRepo prodRepo.WishlistItemRepository
 	wishlistRepo     prodRepo.WishlistRepository
+	variantRepo      prodRepo.VariantRepository
+	productRepo      prodRepo.ProductRepository
 }
 
 // NewWishlistItemService creates a new instance of WishlistItemService
 func NewWishlistItemService(
 	wishlistItemRepo prodRepo.WishlistItemRepository,
 	wishlistRepo prodRepo.WishlistRepository,
+	variantRepo prodRepo.VariantRepository,
+	productRepo prodRepo.ProductRepository,
 ) WishlistItemService {
 	return &wishlistItemServiceImpl{
 		wishlistItemRepo: wishlistItemRepo,
 		wishlistRepo:     wishlistRepo,
+		variantRepo:      variantRepo,
+		productRepo:      productRepo,
 	}
 }
 
 // AddItem adds an item to a wishlist
 // If wishlist has reached MaxWishlistItems (configurable, default 100), removes the oldest item first
+// The req.VariantID is resolved defensively: if the ID is a product ID (not found in the
+// variant table), the product's default variant is used automatically.
 func (s *wishlistItemServiceImpl) AddItem(
 	ctx context.Context,
 	userID, wishlistID uint,
@@ -93,8 +110,14 @@ func (s *wishlistItemServiceImpl) AddItem(
 		return nil, prodErrors.ErrUnauthorizedWishlist
 	}
 
+	// Resolve the variant ID (handles product ID → default variant fallback)
+	variantID, err := s.resolveVariantID(ctx, req.VariantID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Check if item already exists in wishlist
-	exists, err := s.wishlistItemRepo.ExistsByWishlistIDAndVariantID(ctx, wishlistID, req.VariantID)
+	exists, err := s.wishlistItemRepo.ExistsByWishlistIDAndVariantID(ctx, wishlistID, variantID)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +141,7 @@ func (s *wishlistItemServiceImpl) AddItem(
 	// Create wishlist item
 	item := &entity.WishlistItem{
 		WishlistID: wishlistID,
-		VariantID:  req.VariantID,
+		VariantID:  variantID,
 	}
 
 	if err := s.wishlistItemRepo.Create(ctx, item); err != nil {
@@ -131,6 +154,50 @@ func (s *wishlistItemServiceImpl) AddItem(
 		CreatedAt: item.CreatedAt,
 	}, nil
 }
+
+// resolveVariantID resolves an ID to a valid variant ID.
+// If the ID is already a valid variant ID, returns it as-is.
+// If the ID is not a variant but is a valid product ID, finds the product's
+// default variant (IsDefault=true, fallback to lowest ID) and returns that.
+// Returns ErrVariantNotFound if neither a variant nor product is found.
+func (s *wishlistItemServiceImpl) resolveVariantID(ctx context.Context, id uint) (uint, error) {
+	// Try as variant ID first
+	_, err := s.variantRepo.FindVariantByID(ctx, id)
+	if err == nil {
+		return id, nil
+	}
+
+	// If it's not "variant not found", it's a real DB error — propagate it
+	if !errors.Is(err, prodErrors.ErrVariantNotFound) {
+		return 0, err
+	}
+
+	// Try as product ID — find the product's variants and pick the default
+	product, err := s.productRepo.FindByID(ctx, id)
+	if err != nil {
+		// Product not found either — return the original variant-not-found error
+		return 0, prodErrors.ErrVariantNotFound
+	}
+
+	variants, err := s.variantRepo.FindVariantsByProductID(ctx, product.ID)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(variants) == 0 {
+		return 0, prodErrors.ErrVariantNotFound
+	}
+
+	defaultVariant := findDefaultVariantEntity(variants)
+	if defaultVariant == nil {
+		return 0, prodErrors.ErrVariantNotFound
+	}
+
+	return defaultVariant.ID, nil
+}
+
+// findDefaultVariantEntity returns the default variant from a slice.
+// Prefers the variant with IsDefault=true; otherwise returns the one with the lowest ID.
 
 // RemoveItem removes an item from a wishlist
 func (s *wishlistItemServiceImpl) RemoveItem(
@@ -264,4 +331,26 @@ func (s *wishlistItemServiceImpl) AreVariantsInUserWishlist(
 	userID uint,
 ) (map[uint]bool, error) {
 	return s.wishlistItemRepo.AreVariantsInUserWishlist(ctx, variantIDs, userID)
+}
+
+// GetWishlistItemsByVariantIDs returns wishlist item info for variant IDs.
+// Returns map of variantID -> []WishlistItemInfo for efficient per-variant enrichment.
+// Delegates to repository for the raw SQL query.
+func (s *wishlistItemServiceImpl) GetWishlistItemsByVariantIDs(
+	ctx context.Context,
+	variantIDs []uint,
+	userID uint,
+) (map[uint][]model.WishlistItemInfo, error) {
+	items, err := s.wishlistItemRepo.FindWishlistItemsByVariantIDsAndUserID(ctx, variantIDs, userID)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[uint][]model.WishlistItemInfo)
+	for _, item := range items {
+		result[item.VariantID] = append(result[item.VariantID], model.WishlistItemInfo{
+			WishlistItemID: item.ID,
+			WishlistID:     item.WishlistID,
+		})
+	}
+	return result, nil
 }

--- a/product/service/wishlist_service.go
+++ b/product/service/wishlist_service.go
@@ -37,6 +37,7 @@ type WishlistServiceImpl struct {
 	wishlistRepo        repository.WishlistRepository
 	wishlistItemRepo    repository.WishlistItemRepository
 	productQueryService ProductQueryService
+	variantQueryService VariantQueryService
 }
 
 // NewWishlistService creates a new instance of WishlistService
@@ -44,11 +45,13 @@ func NewWishlistService(
 	wishlistRepo repository.WishlistRepository,
 	wishlistItemRepo repository.WishlistItemRepository,
 	productQueryService ProductQueryService,
+	variantQueryService VariantQueryService,
 ) WishlistService {
 	return &WishlistServiceImpl{
 		wishlistRepo:        wishlistRepo,
 		wishlistItemRepo:    wishlistItemRepo,
 		productQueryService: productQueryService,
+		variantQueryService: variantQueryService,
 	}
 }
 
@@ -66,7 +69,8 @@ func (s *WishlistServiceImpl) GetAllWishlists(
 }
 
 // GetWishlistByID retrieves a wishlist with paginated products
-// Uses ProductQueryService to get full product details for wishlist items
+// Returns items with per-wishlist-item metadata (wishlistItemId, variantId, addedAt)
+// alongside full resolved ProductResponse for each item
 func (s *WishlistServiceImpl) GetWishlistByID(
 	ctx context.Context,
 	userID, wishlistID uint,
@@ -88,8 +92,8 @@ func (s *WishlistServiceImpl) GetWishlistByID(
 	page := params.Page
 	pageSize := params.PageSize
 
-	// Get variant IDs from wishlist items with pagination
-	variantIDs, totalItems, err := s.wishlistItemRepo.FindVariantIDsByWishlistID(
+	// Get wishlist items with full metadata (ID, variant_id, created_at)
+	items, totalItems, err := s.wishlistItemRepo.FindWishlistItemsByWishlistID(
 		ctx,
 		wishlistID,
 		page,
@@ -99,45 +103,89 @@ func (s *WishlistServiceImpl) GetWishlistByID(
 		return nil, err
 	}
 
-	// Build products response
-	var productsResponse model.ProductsResponse
+	// Build wishlist product items
+	wishlistItems := make([]model.WishlistProductItem, 0, len(items))
 
-	if len(variantIDs) > 0 {
-		// Get products using the variant IDs filter
-		filter := model.GetProductsFilter{
-			VariantIDs: variantIDs,
+	if len(items) > 0 {
+		// Collect variant IDs for batch product resolution
+		variantIDs := make([]uint, len(items))
+		for i, item := range items {
+			variantIDs[i] = item.VariantID
 		}
-		// Use page 1 and high limit since we already paginated variant IDs
-		// This fetches products for the paginated variant IDs
+
+		// Step 1: Get basic info (variantID → productID) for all wishlist variant IDs.
+		// This bridges the gap since GetAllProducts returns summary products without
+		// full Variants populated (Variants is nil in listing responses).
+		basicInfo, err := s.variantQueryService.GetProductBasicInfoByVariantIDs(
+			ctx,
+			variantIDs,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Build variantID → productID map and collect unique product IDs
+		variantToProductID := make(map[uint]uint, len(basicInfo))
+		uniqueProductIDs := make([]uint, 0, len(basicInfo))
+		seenProductIDs := make(map[uint]struct{}, len(basicInfo))
+		for _, row := range basicInfo {
+			variantToProductID[row.VariantID] = row.ProductID
+			if _, seen := seenProductIDs[row.ProductID]; !seen {
+				seenProductIDs[row.ProductID] = struct{}{}
+				uniqueProductIDs = append(uniqueProductIDs, row.ProductID)
+			}
+		}
+
+		// Step 2: Get full product details using product IDs filter
+		filter := model.GetProductsFilter{
+			IDs: uniqueProductIDs,
+		}
 		products, err := s.productQueryService.GetAllProducts(
 			ctx,
 			1,
-			len(variantIDs),
+			len(uniqueProductIDs),
 			filter,
 			&userID,
 		)
 		if err != nil {
 			return nil, err
 		}
-		productsResponse = model.ProductsResponse{
-			Products:   products.Products,
-			Pagination: common.NewPaginationResponse(page, pageSize, totalItems),
+
+		// Build a map of productID -> ProductResponse for O(1) lookup
+		productByID := make(map[uint]model.ProductResponse, len(products.Products))
+		for _, p := range products.Products {
+			productByID[p.ID] = p
 		}
-	} else {
-		productsResponse = model.ProductsResponse{
-			Products:   []model.ProductResponse{},
-			Pagination: common.NewPaginationResponse(page, pageSize, 0),
+
+		// Step 3: Build items list preserving the order from the query.
+		// Use variantToProductID to find the correct product for each item.
+		for _, item := range items {
+			productID, found := variantToProductID[item.VariantID]
+			if !found {
+				continue // Skip if no product found for this variant
+			}
+			product, found := productByID[productID]
+			if !found {
+				continue // Skip if product details not available
+			}
+			wishlistItems = append(wishlistItems, model.WishlistProductItem{
+				WishlistItemID: item.ID,
+				VariantID:      item.VariantID,
+				AddedAt:        item.CreatedAt,
+				Product:        product,
+			})
 		}
 	}
 
 	return &model.WishlistDetailResponse{
-		ID:        wishlist.ID,
-		Name:      wishlist.Name,
-		IsDefault: wishlist.IsDefault,
-		ItemCount: int(totalItems),
-		Products:  productsResponse,
-		CreatedAt: wishlist.CreatedAt,
-		UpdatedAt: wishlist.UpdatedAt,
+		ID:         wishlist.ID,
+		Name:       wishlist.Name,
+		IsDefault:  wishlist.IsDefault,
+		Items:      wishlistItems,
+		Pagination: common.NewPaginationResponse(page, pageSize, totalItems),
+		CreatedAt:  wishlist.CreatedAt,
+		UpdatedAt:  wishlist.UpdatedAt,
 	}, nil
 }
 

--- a/test/integration/product/product/get_product_by_id/happy_path_test.go
+++ b/test/integration/product/product/get_product_by_id/happy_path_test.go
@@ -9,6 +9,7 @@ import (
 	"ecommerce-be/test/integration/setup"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGetProductByID_HappyPath tests successful scenarios for retrieving a product by ID
@@ -22,6 +23,7 @@ func TestGetProductByID_HappyPath(t *testing.T) {
 	containers.RunAllCoreSeeds(t)
 	containers.RunSeeds(t, "migrations/seeds/mock/001_seed_users.sql")
 	containers.RunSeeds(t, "migrations/seeds/mock/002_seed_products.sql")
+	containers.RunSeeds(t, "migrations/seeds/mock/005_seed_wishlist_data.sql")
 	containers.RunSeeds(t, "test/integration/data/get_product_by_id_seed_data.sql")
 
 	// Setup test server
@@ -105,6 +107,29 @@ func TestGetProductByID_HappyPath(t *testing.T) {
 		assert.NotNil(t, product["variants"], "Variants should be present")
 		assert.NotNil(t, product["options"], "Options should be present")
 		assert.NotNil(t, product["category"], "Category should be present")
+
+		// Verify wishlist item IDs are populated on variants
+		variants, ok := product["variants"].([]any)
+		assert.True(t, ok, "Variants should be an array")
+		assert.NotEmpty(t, variants, "Variants should not be empty")
+
+		// All 4 variants of product 1 are in Alice's wishlists (seed data)
+		for _, v := range variants {
+			variant := v.(map[string]any)
+			assert.True(t, variant["isWishlisted"].(bool),
+				"Variant %v should be wishlisted", variant["id"])
+
+			wishlistItems, ok := variant["wishlistItems"].([]any)
+			assert.True(t, ok, "wishlistItems should be an array for variant %v", variant["id"])
+			assert.NotEmpty(t, wishlistItems, "wishlistItems should not be empty for variant %v", variant["id"])
+
+			item := wishlistItems[0].(map[string]any)
+			assert.NotNil(t, item["wishlistItemId"], "wishlistItemId should be present")
+			assert.NotNil(t, item["wishlistId"], "wishlistId should be present")
+			// variantId should NOT be present (redundant with parent variant id)
+			_, hasVariantID := item["variantId"]
+			assert.False(t, hasVariantID, "variantId should not be in wishlistItems")
+		}
 	})
 
 	// ============================================================================
@@ -322,7 +347,11 @@ func TestGetProductByID_HappyPath(t *testing.T) {
 			"baseSku":    "TEST-SIMPLE-DETAIL-001",
 			"price":      55.50,
 		}
-		createResp := helpers.AssertSuccessResponse(t, client.Post(t, "/api/product", createBody), http.StatusCreated)
+		createResp := helpers.AssertSuccessResponse(
+			t,
+			client.Post(t, "/api/product", createBody),
+			http.StatusCreated,
+		)
 		productID := int(helpers.GetResponseData(t, createResp, "product")["id"].(float64))
 
 		client.SetHeader("X-Seller-ID", fmt.Sprintf("%d", helpers.SellerUserID))
@@ -337,5 +366,94 @@ func TestGetProductByID_HappyPath(t *testing.T) {
 		variants, ok := product["variants"].([]any)
 		assert.True(t, ok)
 		assert.Empty(t, variants, "Simple product detail should not expose placeholder variants")
+	})
+
+	// ============================================================================
+	// HP-08: Simple product wishlisted → product-level wishlistItems (variants stay empty)
+	// ============================================================================
+	t.Run("HP-08: Simple product GET by ID returns product-level wishlistItems", func(t *testing.T) {
+		// Create as seller 2 so Alice (customer with seller context 2) can GET the product
+		sellerToken := helpers.Login(t, client, helpers.Seller2Email, helpers.Seller2Password)
+		client.SetToken(sellerToken)
+
+		createBody := map[string]any{
+			"name":       "Simple Wishlist Detail Product",
+			"categoryId": 4,
+			"baseSku":    "TEST-SIMPLE-WISHLIST-DETAIL-001",
+			"price":      42.00,
+		}
+		createResp := helpers.AssertSuccessResponse(
+			t,
+			client.Post(t, "/api/product", createBody),
+			http.StatusCreated,
+		)
+		productID := int(helpers.GetResponseData(t, createResp, "product")["id"].(float64))
+
+		// Customer wishlists the simple product via product ID (resolves to default placeholder)
+		customerToken := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
+		client.SetToken(customerToken)
+		client.SetHeader("X-Seller-ID", "")
+
+		addResp := helpers.AssertSuccessResponse(
+			t,
+			client.Post(t, "/api/product/wishlist/1/item", map[string]any{
+				"variantId": productID,
+			}),
+			http.StatusCreated,
+		)
+		wishlistItem := helpers.GetResponseData(t, addResp, "wishlistItem")
+		assert.NotNil(t, wishlistItem["id"], "Wishlist item should be created")
+
+		w := client.Get(t, fmt.Sprintf("/api/product/%d", productID))
+		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
+		product := response["data"].(map[string]any)["product"].(map[string]any)
+
+		assert.Equal(t, false, product["hasVariants"], "Simple product should not have public variants")
+		variants, ok := product["variants"].([]any)
+		assert.True(t, ok)
+		assert.Empty(t, variants, "Simple product detail should not expose placeholder variants")
+
+		assert.True(t, product["isWishlisted"].(bool), "Product should be wishlisted")
+
+		wishlistItems, ok := product["wishlistItems"].([]any)
+		require.True(t, ok, "wishlistItems should be present at product level for simple products")
+		require.NotEmpty(t, wishlistItems, "wishlistItems should not be empty when wishlisted")
+
+		item := wishlistItems[0].(map[string]any)
+		assert.NotNil(t, item["wishlistItemId"], "wishlistItemId should be present")
+		assert.Equal(t, float64(1), item["wishlistId"], "wishlistId should be Alice's default wishlist")
+		_, hasVariantID := item["variantId"]
+		assert.False(t, hasVariantID, "variantId should not be in wishlistItems")
+	})
+
+	t.Run("HP-08b: Simple product GET by ID omits wishlistItems when not wishlisted", func(t *testing.T) {
+		sellerToken := helpers.Login(t, client, helpers.Seller2Email, helpers.Seller2Password)
+		client.SetToken(sellerToken)
+
+		createBody := map[string]any{
+			"name":       "Simple Not Wishlisted Product",
+			"categoryId": 4,
+			"baseSku":    "TEST-SIMPLE-NOT-WISHLIST-001",
+			"price":      19.99,
+		}
+		createResp := helpers.AssertSuccessResponse(
+			t,
+			client.Post(t, "/api/product", createBody),
+			http.StatusCreated,
+		)
+		productID := int(helpers.GetResponseData(t, createResp, "product")["id"].(float64))
+
+		customerToken := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
+		client.SetToken(customerToken)
+		client.SetHeader("X-Seller-ID", "")
+
+		w := client.Get(t, fmt.Sprintf("/api/product/%d", productID))
+		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
+		product := response["data"].(map[string]any)["product"].(map[string]any)
+
+		assert.Equal(t, false, product["hasVariants"])
+		assert.False(t, product["isWishlisted"].(bool), "Product should not be wishlisted")
+		_, hasWishlistItems := product["wishlistItems"]
+		assert.False(t, hasWishlistItems, "wishlistItems key should be absent when not wishlisted")
 	})
 }

--- a/test/integration/product/wishlist/add_and_remove_item_test.go
+++ b/test/integration/product/wishlist/add_and_remove_item_test.go
@@ -135,7 +135,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID))
 		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
-		assert.Equal(t, float64(3), wishlist["itemCount"].(float64), "Wishlist should have 3 items")
+		assert.Equal(t, float64(3), getItemCount(wishlist), "Wishlist should have 3 items")
 	})
 
 	t.Run("HP-ADD-003: Add same variant to different wishlists", func(t *testing.T) {
@@ -359,7 +359,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", michaelWishlistID))
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
-		assert.Equal(t, float64(0), wishlist["itemCount"].(float64),
+		assert.Equal(t, float64(0), getItemCount(wishlist),
 			"Michael's wishlist should still have 0 items")
 	})
 
@@ -397,7 +397,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w := client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID))
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
-		countBefore := int(wishlist["itemCount"].(float64))
+		countBefore := int(getItemCount(wishlist))
 
 		// Remove item
 		w = client.Delete(
@@ -410,7 +410,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID))
 		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist = helpers.GetResponseData(t, response, "wishlist")
-		countAfter := int(wishlist["itemCount"].(float64))
+		countAfter := int(getItemCount(wishlist))
 		assert.Equal(t, countBefore-1, countAfter, "Item count should decrease by 1")
 	})
 
@@ -655,7 +655,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID2))
 		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
-		countAfterAdd := int(wishlist["itemCount"].(float64))
+		countAfterAdd := int(getItemCount(wishlist))
 		assert.Greater(t, countAfterAdd, 0, "Should have items after adding")
 
 		// Remove the item
@@ -669,7 +669,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID2))
 		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist = helpers.GetResponseData(t, response, "wishlist")
-		countAfterRemove := int(wishlist["itemCount"].(float64))
+		countAfterRemove := int(getItemCount(wishlist))
 		assert.Equal(t, countAfterAdd-1, countAfterRemove, "Item count should decrease by 1")
 
 		// Verify item is gone from database
@@ -704,7 +704,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", testWishlistID))
 		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
-		assert.Equal(t, float64(1), wishlist["itemCount"].(float64), "Should have 1 item")
+		assert.Equal(t, float64(1), getItemCount(wishlist), "Should have 1 item")
 
 		// Remove item
 		w = client.Delete(
@@ -717,7 +717,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		w = client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", testWishlistID))
 		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist = helpers.GetResponseData(t, response, "wishlist")
-		assert.Equal(t, float64(0), wishlist["itemCount"].(float64), "Should have 0 items")
+		assert.Equal(t, float64(0), getItemCount(wishlist), "Should have 0 items")
 	})
 
 	t.Run("INT-003: Multiple users can have same variant in their wishlists", func(t *testing.T) {
@@ -745,7 +745,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		aliceWishlistData := helpers.GetResponseData(t, response, "wishlist")
 		assert.Greater(
 			t,
-			aliceWishlistData["itemCount"].(float64),
+			getItemCount(aliceWishlistData),
 			float64(0),
 			"Alice should have items",
 		)
@@ -756,7 +756,7 @@ func TestAddAndRemoveWishlistItem(t *testing.T) {
 		michaelWishlistData := helpers.GetResponseData(t, response, "wishlist")
 		assert.Greater(
 			t,
-			michaelWishlistData["itemCount"].(float64),
+			getItemCount(michaelWishlistData),
 			float64(0),
 			"Michael should have items",
 		)

--- a/test/integration/product/wishlist/delete_wishlist_test.go
+++ b/test/integration/product/wishlist/delete_wishlist_test.go
@@ -168,10 +168,12 @@ func TestDeleteWishlist(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		// Check itemCount safely (may be 0 if products weren't available in seed data)
+		// Check totalItems from pagination (may be 0 if products weren't available in seed data)
 		var itemCount int
-		if itemCountRaw, ok := wishlist["itemCount"]; ok && itemCountRaw != nil {
-			itemCount = int(itemCountRaw.(float64))
+		if paginationRaw, ok := wishlist["pagination"].(map[string]any); ok {
+			if totalItemsRaw, ok := paginationRaw["totalItems"]; ok && totalItemsRaw != nil {
+				itemCount = int(totalItemsRaw.(float64))
+			}
 		}
 		t.Logf("Wishlist has %d items before deletion", itemCount)
 

--- a/test/integration/product/wishlist/get_wishlist_by_id_test.go
+++ b/test/integration/product/wishlist/get_wishlist_by_id_test.go
@@ -12,15 +12,16 @@ import (
 )
 
 // TestGetWishlistByID tests the Get Wishlist By ID (GET /api/product/wishlist/:id) API
-// This endpoint retrieves a single wishlist with paginated products.
+// This endpoint retrieves a single wishlist with paginated items.
 //
 // Endpoint: GET /api/product/wishlist/:id
 // Query Params: page (default: 1), pageSize (default: 20, max: 100)
 // Authentication: Required (Customer Auth only)
 //
 // Response includes:
-//   - Wishlist details (id, name, isDefault, itemCount, timestamps)
-//   - Paginated products with full details
+//   - Wishlist details (id, name, isDefault, timestamps)
+//   - Paginated items array with per-item metadata (wishlistItemId, variantId, addedAt) + full product
+//   - Top-level pagination
 func TestGetWishlistByID(t *testing.T) {
 	// Setup test containers
 	containers := setup.SetupTestContainers(t)
@@ -64,40 +65,22 @@ func TestGetWishlistByID(t *testing.T) {
 	aliceWishlist2 := helpers.GetResponseData(t, response, "wishlist")
 	aliceWishlistID2 := uint(aliceWishlist2["id"].(float64))
 
-	// Add items to first wishlist (need to get variant IDs first)
-	// Get products from seller 2
-	client.SetHeader("X-Seller-ID", "2")
-	w = client.Get(t, "/api/product?page=1&pageSize=5")
-	response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
-	data := response["data"].(map[string]any)
+	// Add items to first wishlist using known variant IDs from seed data
+	// Seed data has variants: 1 (iPhone 15 Pro), 5 (Samsung S24), 9 (Nike T-Shirt)
+	variantIDs := []uint{1, 5, 9}
+	addedVariantIDs := make([]uint, 0, len(variantIDs))
 
-	// Add first 3 product variants to wishlist
-	// Note: We track added variants for verification in HP-001 test
-	addedVariantIDs := make([]uint, 0, 3)
-	if resultsRaw, ok := data["results"]; ok && resultsRaw != nil {
-		products := resultsRaw.([]any)
-		for i := 0; i < 3 && i < len(products); i++ {
-			product := products[i].(map[string]any)
-			if variantsRaw, ok := product["variants"]; ok && variantsRaw != nil {
-				variants := variantsRaw.([]any)
-				if len(variants) > 0 {
-					variant := variants[0].(map[string]any)
-					variantID := uint(variant["id"].(float64))
-					addedVariantIDs = append(addedVariantIDs, variantID)
-
-					// Add to wishlist
-					addReq := map[string]any{
-						"variantId": variantID,
-					}
-					w = client.Post(
-						t,
-						fmt.Sprintf("/api/product/wishlist/%d/item", aliceWishlistID),
-						addReq,
-					)
-					helpers.AssertSuccessResponse(t, w, http.StatusCreated)
-				}
-			}
+	for _, variantID := range variantIDs {
+		addReq := map[string]any{
+			"variantId": variantID,
 		}
+		w = client.Post(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d/item", aliceWishlistID),
+			addReq,
+		)
+		helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+		addedVariantIDs = append(addedVariantIDs, variantID)
 	}
 
 	// Login as Michael (user 6) and create wishlist for authorization tests
@@ -116,12 +99,12 @@ func TestGetWishlistByID(t *testing.T) {
 	// Happy Path Scenarios
 	// ============================================================================
 
-	t.Run("HP-001: Get wishlist by ID with products", func(t *testing.T) {
+	t.Run("HP-001: Get wishlist by ID with items", func(t *testing.T) {
 		// Login as Alice
 		token := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
 		client.SetToken(token)
 
-		// Get wishlist with products
+		// Get wishlist with items
 		w := client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID))
 
 		// Assert response
@@ -132,27 +115,37 @@ func TestGetWishlistByID(t *testing.T) {
 		assert.Equal(t, float64(aliceWishlistID), wishlist["id"].(float64), "ID should match")
 		assert.Equal(t, "Alice Tech Wishlist", wishlist["name"], "Name should match")
 		assert.True(t, wishlist["isDefault"].(bool), "First wishlist should be default")
-		assert.NotNil(t, wishlist["itemCount"], "Should have itemCount")
 		assert.NotNil(t, wishlist["createdAt"], "Should have createdAt")
 		assert.NotNil(t, wishlist["updatedAt"], "Should have updatedAt")
 
-		// Validate products - handle the case where products may be a struct or map
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			assert.NotNil(t, productsData["products"], "Should have products array")
-			assert.NotNil(t, productsData["pagination"], "Should have pagination")
+		// Validate items array
+		itemsData, ok := wishlist["items"].([]any)
+		assert.True(t, ok, "Items field should be an array")
+		assert.GreaterOrEqual(t, len(itemsData), 1, "Should have at least 1 item")
 
-			// Validate pagination
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				assert.NotNil(t, paginationRaw["currentPage"], "Should have currentPage")
-				assert.NotNil(t, paginationRaw["totalItems"], "Should have totalItems")
-				assert.NotNil(t, paginationRaw["itemsPerPage"], "Should have itemsPerPage")
-			}
+		// Validate each item has required metadata fields
+		for _, itemRaw := range itemsData {
+			item := itemRaw.(map[string]any)
+			assert.NotNil(t, item["wishlistItemId"], "Item should have wishlistItemId")
+			assert.NotNil(t, item["variantId"], "Item should have variantId")
+			assert.NotNil(t, item["addedAt"], "Item should have addedAt")
+			assert.NotNil(t, item["product"], "Item should have product object")
+
+			product, ok := item["product"].(map[string]any)
+			assert.True(t, ok, "Product should be a map")
+			assert.NotNil(t, product["id"], "Product should have id")
+			assert.NotNil(t, product["name"], "Product should have name")
 		}
+
+		// Validate pagination at top level
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.NotNil(t, pagination["currentPage"], "Should have currentPage")
+		assert.NotNil(t, pagination["totalItems"], "Should have totalItems")
+		assert.NotNil(t, pagination["itemsPerPage"], "Should have itemsPerPage")
 	})
 
-	t.Run("HP-002: Get empty wishlist (no products)", func(t *testing.T) {
+	t.Run("HP-002: Get empty wishlist (no items)", func(t *testing.T) {
 		// Login as Alice
 		token := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
 		client.SetToken(token)
@@ -165,37 +158,30 @@ func TestGetWishlistByID(t *testing.T) {
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
 		// Validate empty state
-		assert.Equal(t, float64(0), wishlist["itemCount"].(float64), "itemCount should be 0")
 		assert.False(t, wishlist["isDefault"].(bool), "Second wishlist should not be default")
 
-		// Validate empty products
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			// Products array may be nil or empty
-			if productsListRaw := productsData["products"]; productsListRaw != nil {
-				productsList := productsListRaw.([]any)
-				assert.Equal(t, 0, len(productsList), "Products array should be empty")
-			}
+		// Validate empty items array
+		itemsData, ok := wishlist["items"].([]any)
+		assert.True(t, ok, "Items field should be an array")
+		assert.Equal(t, 0, len(itemsData), "Items array should be empty")
 
-			// Validate pagination for empty state
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				assert.Equal(
-					t,
-					float64(0),
-					paginationRaw["totalItems"].(float64),
-					"totalItems should be 0",
-				)
-				assert.Equal(
-					t,
-					float64(0),
-					paginationRaw["totalPages"].(float64),
-					"totalPages should be 0",
-				)
-				assert.False(t, paginationRaw["hasNext"].(bool), "hasNext should be false")
-				assert.False(t, paginationRaw["hasPrev"].(bool), "hasPrev should be false")
-			}
-		}
+		// Validate pagination for empty state at top level
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(0),
+			pagination["totalItems"].(float64),
+			"totalItems should be 0",
+		)
+		assert.Equal(
+			t,
+			float64(0),
+			pagination["totalPages"].(float64),
+			"totalPages should be 0",
+		)
+		assert.False(t, pagination["hasNext"].(bool), "hasNext should be false")
+		assert.False(t, pagination["hasPrev"].(bool), "hasPrev should be false")
 	})
 
 	t.Run("HP-003: Get default wishlist by ID", func(t *testing.T) {
@@ -245,27 +231,21 @@ func TestGetWishlistByID(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		// Validate pagination
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			pagination, pOk := productsData["pagination"].(map[string]any)
-			assert.True(t, pOk, "Pagination should be a map")
-			if pOk {
-				assert.Equal(
-					t,
-					float64(1),
-					pagination["currentPage"].(float64),
-					"currentPage should be 1",
-				)
-				assert.Equal(
-					t,
-					float64(2),
-					pagination["itemsPerPage"].(float64),
-					"itemsPerPage should be 2",
-				)
-			}
-		}
+		// Validate pagination at top level
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(1),
+			pagination["currentPage"].(float64),
+			"currentPage should be 1",
+		)
+		assert.Equal(
+			t,
+			float64(2),
+			pagination["itemsPerPage"].(float64),
+			"itemsPerPage should be 2",
+		)
 	})
 
 	t.Run("HP-006: Get wishlist with default pagination values", func(t *testing.T) {
@@ -280,27 +260,21 @@ func TestGetWishlistByID(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		// Validate default pagination
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			pagination, pOk := productsData["pagination"].(map[string]any)
-			assert.True(t, pOk, "Pagination should be a map")
-			if pOk {
-				assert.Equal(
-					t,
-					float64(1),
-					pagination["currentPage"].(float64),
-					"Default currentPage should be 1",
-				)
-				assert.Equal(
-					t,
-					float64(20),
-					pagination["itemsPerPage"].(float64),
-					"Default itemsPerPage should be 20",
-				)
-			}
-		}
+		// Validate default pagination at top level
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(1),
+			pagination["currentPage"].(float64),
+			"Default currentPage should be 1",
+		)
+		assert.Equal(
+			t,
+			float64(20),
+			pagination["itemsPerPage"].(float64),
+			"Default itemsPerPage should be 20",
+		)
 	})
 
 	// ============================================================================
@@ -414,7 +388,6 @@ func TestGetWishlistByID(t *testing.T) {
 
 		w := client.Get(t, "/api/product/wishlist/0")
 
-		// ID 0 is invalid - should return 400 Bad Request
 		helpers.AssertErrorResponse(t, w, http.StatusNotFound)
 	})
 
@@ -444,33 +417,28 @@ func TestGetWishlistByID(t *testing.T) {
 			fmt.Sprintf("/api/product/wishlist/%d?page=100&pageSize=20", aliceWishlistID),
 		)
 
-		// Should return 200 with empty products array
+		// Should return 200 with empty items array
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			if productsListRaw := productsData["products"]; productsListRaw != nil {
-				productsList := productsListRaw.([]any)
-				assert.Equal(
-					t,
-					0,
-					len(productsList),
-					"Products array should be empty for page beyond total",
-				)
-			}
+		itemsData, ok := wishlist["items"].([]any)
+		assert.True(t, ok, "Items field should be an array")
+		assert.Equal(
+			t,
+			0,
+			len(itemsData),
+			"Items array should be empty for page beyond total",
+		)
 
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				assert.Equal(
-					t,
-					float64(100),
-					paginationRaw["currentPage"].(float64),
-					"currentPage should be 100",
-				)
-				assert.False(t, paginationRaw["hasNext"].(bool), "hasNext should be false")
-			}
-		}
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(100),
+			pagination["currentPage"].(float64),
+			"currentPage should be 100",
+		)
+		assert.False(t, pagination["hasNext"].(bool), "hasNext should be false")
 	})
 
 	t.Run("EDGE-003: Get wishlist with pageSize exceeding max capped to 100", func(t *testing.T) {
@@ -485,18 +453,14 @@ func TestGetWishlistByID(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				assert.Equal(
-					t,
-					float64(100),
-					paginationRaw["itemsPerPage"].(float64),
-					"pageSize should be capped to 100",
-				)
-			}
-		}
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(100),
+			pagination["itemsPerPage"].(float64),
+			"pageSize should be capped to 100",
+		)
 	})
 
 	t.Run("EDGE-004: Get wishlist with pageSize zero uses default", func(t *testing.T) {
@@ -510,18 +474,14 @@ func TestGetWishlistByID(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				assert.Equal(
-					t,
-					float64(20),
-					paginationRaw["itemsPerPage"].(float64),
-					"pageSize should default to 20",
-				)
-			}
-		}
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(20),
+			pagination["itemsPerPage"].(float64),
+			"pageSize should default to 20",
+		)
 	})
 
 	t.Run("EDGE-005: Get wishlist with negative page uses default", func(t *testing.T) {
@@ -535,18 +495,14 @@ func TestGetWishlistByID(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				assert.Equal(
-					t,
-					float64(1),
-					paginationRaw["currentPage"].(float64),
-					"page should default to 1",
-				)
-			}
-		}
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		assert.Equal(
+			t,
+			float64(1),
+			pagination["currentPage"].(float64),
+			"page should default to 1",
+		)
 	})
 
 	// ============================================================================
@@ -614,7 +570,7 @@ func TestGetWishlistByID(t *testing.T) {
 	// Business Logic Scenarios
 	// ============================================================================
 
-	t.Run("BL-001: itemCount matches actual items in wishlist", func(t *testing.T) {
+	t.Run("BL-001: pagination totalItems matches actual items in wishlist", func(t *testing.T) {
 		// Login as Alice
 		token := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
 		client.SetToken(token)
@@ -624,47 +580,42 @@ func TestGetWishlistByID(t *testing.T) {
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		itemCount := int(wishlist["itemCount"].(float64))
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			if paginationRaw, pOk := productsData["pagination"].(map[string]any); pOk {
-				totalItems := int(paginationRaw["totalItems"].(float64))
-				// itemCount should equal totalItems in pagination
-				assert.Equal(
-					t,
-					itemCount,
-					totalItems,
-					"itemCount should match pagination totalItems",
-				)
-			}
-		}
+		itemsData, ok := wishlist["items"].([]any)
+		assert.True(t, ok, "Items field should be an array")
+
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+
+		totalItems := int(pagination["totalItems"].(float64))
+		// pagination.totalItems equals total items in DB (not just current page)
+		assert.GreaterOrEqual(t, totalItems, len(itemsData), "totalItems should be >= items on page")
 	})
 
-	t.Run("BL-002: Products have required fields", func(t *testing.T) {
+	t.Run("BL-002: Items have required fields", func(t *testing.T) {
 		// Login as Alice
 		token := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
 		client.SetToken(token)
 
-		// Get wishlist with products
+		// Get wishlist with items
 		w := client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID))
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
 
-		productsData, ok := wishlist["products"].(map[string]any)
-		assert.True(t, ok, "Products field should be a map")
-		if ok {
-			if productsListRaw := productsData["products"]; productsListRaw != nil {
-				productsList := productsListRaw.([]any)
-				if len(productsList) > 0 {
-					product := productsList[0].(map[string]any)
+		itemsData, ok := wishlist["items"].([]any)
+		assert.True(t, ok, "Items field should be an array")
+		if len(itemsData) > 0 {
+			item := itemsData[0].(map[string]any)
 
-					// Verify product has required fields
-					assert.NotNil(t, product["id"], "Product should have id")
-					assert.NotNil(t, product["name"], "Product should have name")
-					assert.NotNil(t, product["variants"], "Product should have variants")
-				}
-			}
+			// Verify item has metadata fields
+			assert.NotNil(t, item["wishlistItemId"], "Item should have wishlistItemId")
+			assert.NotNil(t, item["variantId"], "Item should have variantId")
+			assert.NotNil(t, item["addedAt"], "Item should have addedAt")
+
+			// Verify nested product has required fields
+			product, ok := item["product"].(map[string]any)
+			assert.True(t, ok, "Product should be a map")
+			assert.NotNil(t, product["id"], "Product should have id")
+			assert.NotNil(t, product["name"], "Product should have name")
 		}
 	})
 
@@ -694,57 +645,43 @@ func TestGetWishlistByID(t *testing.T) {
 		token := helpers.Login(t, client, helpers.Customer2Email, helpers.Customer2Password)
 		client.SetToken(token)
 
-		// Get initial item count
+		// Get initial item count from pagination
 		w := client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", michaelWishlistID))
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		wishlist := helpers.GetResponseData(t, response, "wishlist")
-		initialCount := int(wishlist["itemCount"].(float64))
 
-		// Get a variant to add
-		client.SetHeader("X-Seller-ID", "3")
-		w = client.Get(t, "/api/product?page=1&pageSize=1")
-		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
-		data := response["data"].(map[string]any)
+		pagination, ok := wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		initialCount := int(pagination["totalItems"].(float64))
 
-		if resultsRaw, ok := data["results"]; ok && resultsRaw != nil {
-			products := resultsRaw.([]any)
-			if len(products) > 0 {
-				product := products[0].(map[string]any)
-				if variantsRaw, vOk := product["variants"]; vOk && variantsRaw != nil {
-					variants := variantsRaw.([]any)
-					if len(variants) > 0 {
-						variant := variants[0].(map[string]any)
-						variantID := uint(variant["id"].(float64))
-
-						// Add item to wishlist
-						addReq := map[string]any{
-							"variantId": variantID,
-						}
-						w = client.Post(
-							t,
-							fmt.Sprintf("/api/product/wishlist/%d/item", michaelWishlistID),
-							addReq,
-						)
-						helpers.AssertSuccessResponse(t, w, http.StatusCreated)
-
-						// Get wishlist again - should have one more item
-						w = client.Get(
-							t,
-							fmt.Sprintf("/api/product/wishlist/%d", michaelWishlistID),
-						)
-						response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
-						wishlist = helpers.GetResponseData(t, response, "wishlist")
-						newCount := int(wishlist["itemCount"].(float64))
-
-						assert.Equal(
-							t,
-							initialCount+1,
-							newCount,
-							"itemCount should increase by 1 after adding item",
-						)
-					}
-				}
-			}
+		// Add an item to Michael's wishlist using known variant ID from seed data
+		addReq := map[string]any{
+			"variantId": uint(14), // Running shoes variant
 		}
+		w = client.Post(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d/item", michaelWishlistID),
+			addReq,
+		)
+		helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+
+		// Get wishlist again - should have one more item
+		w = client.Get(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d", michaelWishlistID),
+		)
+		response = helpers.AssertSuccessResponse(t, w, http.StatusOK)
+		wishlist = helpers.GetResponseData(t, response, "wishlist")
+
+		pagination, ok = wishlist["pagination"].(map[string]any)
+		assert.True(t, ok, "Pagination should be at top level")
+		newCount := int(pagination["totalItems"].(float64))
+
+		assert.Equal(
+			t,
+			initialCount+1,
+			newCount,
+			"totalItems should increase by 1 after adding item",
+		)
 	})
 }

--- a/test/integration/product/wishlist/move_item_test.go
+++ b/test/integration/product/wishlist/move_item_test.go
@@ -201,7 +201,7 @@ func TestMoveWishlistItem(t *testing.T) {
 		assert.Equal(
 			t,
 			float64(1),
-			wishlist["itemCount"].(float64),
+			getItemCount(wishlist),
 			"Source should have 1 item left",
 		)
 
@@ -212,7 +212,7 @@ func TestMoveWishlistItem(t *testing.T) {
 		assert.Equal(
 			t,
 			float64(1),
-			wishlist["itemCount"].(float64),
+			getItemCount(wishlist),
 			"Third wishlist should have 1 item",
 		)
 	})
@@ -840,7 +840,7 @@ func TestMoveWishlistItem(t *testing.T) {
 		assert.Equal(
 			t,
 			float64(1),
-			sourceWishlist["itemCount"].(float64),
+			getItemCount(sourceWishlist),
 			"Source should have 1 item",
 		)
 
@@ -850,7 +850,7 @@ func TestMoveWishlistItem(t *testing.T) {
 		assert.Equal(
 			t,
 			float64(0),
-			targetWishlist["itemCount"].(float64),
+			getItemCount(targetWishlist),
 			"Target should have 0 items",
 		)
 
@@ -870,7 +870,7 @@ func TestMoveWishlistItem(t *testing.T) {
 		assert.Equal(
 			t,
 			float64(0),
-			sourceWishlist["itemCount"].(float64),
+			getItemCount(sourceWishlist),
 			"Source should have 0 items after move",
 		)
 
@@ -880,7 +880,7 @@ func TestMoveWishlistItem(t *testing.T) {
 		assert.Equal(
 			t,
 			float64(1),
-			targetWishlist["itemCount"].(float64),
+			getItemCount(targetWishlist),
 			"Target should have 1 item after move",
 		)
 	})

--- a/test/integration/product/wishlist/product_id_resolution_test.go
+++ b/test/integration/product/wishlist/product_id_resolution_test.go
@@ -1,0 +1,283 @@
+package wishlist
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"ecommerce-be/test/integration/helpers"
+	"ecommerce-be/test/integration/setup"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProductIDResolutionForWishlistItem verifies that when the wishlist AddItem API
+// receives a product ID (instead of a variant ID) in the variantId field, it
+// defensively resolves it to the product's default variant.
+//
+// Endpoints:
+//   - POST /api/product/wishlist/:id/item - Add item to wishlist
+//
+// IMPORTANT: The standard seed data (002_seed_products.sql) has product IDs (1-9)
+// that overlap with variant IDs (1-20), so FindVariantByID(X) succeeds for product
+// IDs 1-9 without ever reaching the product-ID fallback. To properly test the
+// resolution logic, we insert dedicated test products with IDs (100+) that cannot
+// collide with any existing variant IDs.
+//
+// Test product data inserted by this test:
+//   - Product 100 (ResolutionSingle) → variant 200 (is_default=true, only variant)
+//   - Product 101 (ResolutionMulti)  → variants 201 (is_default=true), 202, 203
+//   - Product 102 (ResolutionOther)  → variant 204 (is_default=true, only variant)
+func TestProductIDResolutionForWishlistItem(t *testing.T) {
+	// Setup test containers
+	containers := setup.SetupTestContainers(t)
+	defer containers.Cleanup(t)
+
+	// Run migrations and seeds
+	containers.RunAllMigrations(t)
+	containers.RunAllCoreSeeds(t)
+	containers.RunSeeds(t, "migrations/seeds/mock/001_seed_users.sql")
+	containers.RunSeeds(t, "migrations/seeds/mock/002_seed_products.sql")
+
+	// Insert dedicated test products with IDs that cannot collide with any variant ID.
+	// Standard seed variant IDs go up to 20, so using 100+ guarantees no collision.
+	sqlDB, err := containers.DB.DB()
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`
+		INSERT INTO product (id, name, category_id, brand, base_sku, short_description, long_description, seller_id, created_at, updated_at) VALUES
+		(100, 'ResolutionTest Single Variant', 4, 'TestBrand', 'RES-SINGLE', 'Single variant product', 'Single variant for resolution testing', 2, NOW(), NOW()),
+		(101, 'ResolutionTest Multi Variant', 4, 'TestBrand', 'RES-MULTI', 'Multi variant product', 'Multiple variants for resolution testing', 2, NOW(), NOW()),
+		(102, 'ResolutionTest Other', 4, 'TestBrand', 'RES-OTHER', 'Other single variant', 'Another single variant product', 2, NOW(), NOW())
+		ON CONFLICT (id) DO NOTHING;
+
+		INSERT INTO product_variant (id, product_id, sku, price, allow_purchase, is_popular, is_default) VALUES
+		(200, 100, 'RES-SINGLE-200', 10.00, true, true, true),
+		(201, 101, 'RES-MULTI-201', 10.00, true, true, true),
+		(202, 101, 'RES-MULTI-202', 15.00, true, false, false),
+		(203, 101, 'RES-MULTI-203', 20.00, true, false, false),
+		(204, 102, 'RES-OTHER-204', 25.00, true, true, true)
+		ON CONFLICT (id) DO NOTHING;
+
+		SELECT setval('product_id_seq', GREATEST((SELECT COALESCE(MAX(id), 0) FROM product), 102));
+		SELECT setval('product_variant_id_seq', GREATEST((SELECT COALESCE(MAX(id), 0) FROM product_variant), 204));
+	`)
+	require.NoError(t, err)
+
+	// Setup test server
+	server := setup.SetupTestServer(t, containers.DB, containers.RedisClient)
+
+	// Create API client
+	client := helpers.NewAPIClient(server)
+
+	// Login as customer (Alice - user 5)
+	token := helpers.Login(t, client, helpers.CustomerEmail, helpers.CustomerPassword)
+	client.SetToken(token)
+
+	// Create wishlist for Alice
+	w := client.Post(t, "/api/product/wishlist", map[string]any{
+		"name": "Resolution Test Wishlist",
+	})
+	response := helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+	wishlistData := helpers.GetResponseData(t, response, "wishlist")
+	wishlistID := uint(wishlistData["id"].(float64))
+
+	// Create a second wishlist for multi-wishlist tests
+	w = client.Post(t, "/api/product/wishlist", map[string]any{
+		"name": "Second Resolution Wishlist",
+	})
+	response = helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+	wishlistData2 := helpers.GetResponseData(t, response, "wishlist")
+	wishlistID2 := uint(wishlistData2["id"].(float64))
+
+	// ============================================================================
+	// HAPPY PATH: Product ID → Default Variant Resolution
+	// ============================================================================
+
+	t.Run(
+		"HP-RESOLVE-001: Product ID resolves to its default variant (single variant product)",
+		func(t *testing.T) {
+			// Product 100 has only variant 200 (is_default=true)
+			productID := uint(100)
+			expectedVariantID := uint(200)
+
+			w := client.Post(
+				t,
+				fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+				map[string]any{
+					"variantId": productID,
+				},
+			)
+			response := helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+
+			item := helpers.GetResponseData(t, response, "wishlistItem")
+			assert.NotNil(t, item["id"], "Item should have ID")
+			assert.Equal(t, float64(expectedVariantID), item["variantId"],
+				"Should resolve product ID 100 to default variant 200")
+		},
+	)
+
+	t.Run(
+		"HP-RESOLVE-002: Product ID resolves to default when product has multiple variants",
+		func(t *testing.T) {
+			// Product 101 has variants 201-203, variant 201 is is_default=true
+			productID := uint(101)
+			expectedVariantID := uint(201)
+
+			w := client.Post(
+				t,
+				fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+				map[string]any{
+					"variantId": productID,
+				},
+			)
+			response := helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+
+			item := helpers.GetResponseData(t, response, "wishlistItem")
+			assert.Equal(t, float64(expectedVariantID), item["variantId"],
+				"Should resolve product ID 101 to default variant 201")
+		},
+	)
+
+	t.Run("HP-RESOLVE-003: Valid variant ID still works (backward compatible)", func(t *testing.T) {
+		// Variant 202 is a valid variant ID for product 101 (not the default)
+		variantID := uint(202)
+
+		w := client.Post(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+			map[string]any{
+				"variantId": variantID,
+			},
+		)
+		response := helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+
+		item := helpers.GetResponseData(t, response, "wishlistItem")
+		assert.Equal(t, float64(variantID), item["variantId"],
+			"Valid variant ID should be used as-is without resolution")
+	})
+
+	t.Run(
+		"HP-RESOLVE-004: Same product ID resolves to same default variant consistently",
+		func(t *testing.T) {
+			// Product 102 has variant 204 (is_default=true)
+			productID := uint(102)
+			expectedVariantID := uint(204)
+
+			w := client.Post(
+				t,
+				fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID2),
+				map[string]any{
+					"variantId": productID,
+				},
+			)
+			response := helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+
+			item := helpers.GetResponseData(t, response, "wishlistItem")
+			assert.Equal(t, float64(expectedVariantID), item["variantId"],
+				"Should resolve product ID 102 to default variant 204")
+		},
+	)
+
+	// ============================================================================
+	// HAPPY PATH: Mixed Scenarios
+	// ============================================================================
+
+	t.Run(
+		"HP-RESOLVE-005: Add product ID then add one of its specific variant IDs",
+		func(t *testing.T) {
+			// Product 101: default = 201, other variant = 203
+			// This tests that adding a specific variant of a product whose default was
+			// already resolved works fine (they are different variant IDs in the wishlist).
+			specificVariantID := uint(203)
+
+			w := client.Post(
+				t,
+				fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+				map[string]any{
+					"variantId": specificVariantID,
+				},
+			)
+			response := helpers.AssertSuccessResponse(t, w, http.StatusCreated)
+			item := helpers.GetResponseData(t, response, "wishlistItem")
+			assert.Equal(t, float64(specificVariantID), item["variantId"],
+				"Specific variant ID should work alongside resolved product IDs")
+		},
+	)
+
+	// ============================================================================
+	// NEGATIVE SCENARIOS
+	// ============================================================================
+
+	t.Run("NEG-RESOLVE-001: Non-existent ID returns 404", func(t *testing.T) {
+		w := client.Post(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+			map[string]any{
+				"variantId": 99999,
+			},
+		)
+		helpers.AssertErrorResponse(t, w, http.StatusNotFound)
+	})
+
+	t.Run("NEG-RESOLVE-002: Duplicate after product-ID resolution returns 409", func(t *testing.T) {
+		// Product ID 100 was already added in HP-RESOLVE-001, which resolved to variant 200.
+		// Adding product ID 100 again should detect the duplicate on variant 200.
+		w := client.Post(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+			map[string]any{
+				"variantId": 100,
+			},
+		)
+		helpers.AssertErrorResponse(t, w, http.StatusConflict)
+	})
+
+	t.Run(
+		"NEG-RESOLVE-003: Duplicate when adding the resolved variant directly returns 409",
+		func(t *testing.T) {
+			// Variant 200 was already added (via product ID 100 resolution in HP-RESOLVE-001).
+			// Adding variant 200 directly should also be detected as duplicate.
+			w := client.Post(
+				t,
+				fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+				map[string]any{
+					"variantId": 200,
+				},
+			)
+			helpers.AssertErrorResponse(t, w, http.StatusConflict)
+		},
+	)
+
+	// ============================================================================
+	// EDGE CASES
+	// ============================================================================
+
+	t.Run("EDGE-RESOLVE-001: Product ID 0 returns error", func(t *testing.T) {
+		w := client.Post(
+			t,
+			fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+			map[string]any{
+				"variantId": 0,
+			},
+		)
+		assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusNotFound,
+			"Should reject variantId 0, got %d", w.Code)
+	})
+
+	t.Run(
+		"EDGE-RESOLVE-002: Add product ID to same wishlist twice is duplicate",
+		func(t *testing.T) {
+			// Product 101 was already added in HP-RESOLVE-002
+			w := client.Post(
+				t,
+				fmt.Sprintf("/api/product/wishlist/%d/item", wishlistID),
+				map[string]any{
+					"variantId": 101,
+				},
+			)
+			helpers.AssertErrorResponse(t, w, http.StatusConflict)
+		},
+	)
+}

--- a/test/integration/product/wishlist/test_helpers.go
+++ b/test/integration/product/wishlist/test_helpers.go
@@ -1,0 +1,15 @@
+package wishlist
+
+// getItemCount extracts the total item count from a GET by ID wishlist response.
+// In the detail response, itemCount was replaced by pagination.totalItems.
+func getItemCount(wishlist map[string]any) float64 {
+	pagination, ok := wishlist["pagination"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	totalItems, ok := pagination["totalItems"].(float64)
+	if !ok {
+		return 0
+	}
+	return totalItems
+}

--- a/test/integration/product/wishlist/update_wishlist_test.go
+++ b/test/integration/product/wishlist/update_wishlist_test.go
@@ -705,7 +705,7 @@ func TestUpdateWishlist(t *testing.T) {
 		w := client.Get(t, fmt.Sprintf("/api/product/wishlist/%d", aliceWishlistID))
 		response := helpers.AssertSuccessResponse(t, w, http.StatusOK)
 		originalWishlist := helpers.GetResponseData(t, response, "wishlist")
-		originalItemCount := originalWishlist["itemCount"].(float64)
+		originalItemCount := getItemCount(originalWishlist)
 
 		// Update name
 		updateReq := map[string]any{

--- a/test/integration/user/address_test.go
+++ b/test/integration/user/address_test.go
@@ -1,0 +1,155 @@
+package user
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"ecommerce-be/test/integration/helpers"
+	"ecommerce-be/test/integration/setup"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const AddressAPIEndpoint = "/api/user/address"
+
+// AddressTestSuite proves and guards address create/update/default flows.
+// Notably: creating/updating with isDefault=true must not fail address-type
+// validation when clearing sibling defaults (GORM empty-model hooks bug).
+type AddressTestSuite struct {
+	suite.Suite
+	container      *setup.TestContainer
+	server         http.Handler
+	customerClient *helpers.APIClient
+}
+
+func (s *AddressTestSuite) SetupSuite() {
+	s.container = setup.SetupTestContainers(s.T())
+	s.container.RunAllMigrations(s.T())
+	s.container.RunAllSeeds(s.T())
+
+	s.server = setup.SetupTestServer(s.T(), s.container.DB, s.container.RedisClient)
+
+	s.customerClient = helpers.NewAPIClient(s.server)
+	token := helpers.Login(
+		s.T(),
+		s.customerClient,
+		helpers.CustomerEmail,
+		helpers.CustomerPassword,
+	)
+	s.customerClient.SetToken(token)
+}
+
+func (s *AddressTestSuite) TearDownSuite() {
+	if s.container != nil {
+		s.container.Cleanup(s.T())
+	}
+}
+
+func TestAddressSuite(t *testing.T) {
+	suite.Run(t, new(AddressTestSuite))
+}
+
+func (s *AddressTestSuite) validCreatePayload(isDefault bool) map[string]any {
+	return map[string]any{
+		"type":      "HOME",
+		"address":   "Amee Residency A Block",
+		"landmark":  "Near ring road",
+		"city":      "Rajkot",
+		"state":     "Gujarat",
+		"zipCode":   "360005",
+		"countryId": 1,
+		"isDefault": isDefault,
+	}
+}
+
+// TestCreateDefaultAddressSucceedsWhenUserAlreadyHasAddresses
+// Customer seed user (id=5) already has addresses. Creating another as default
+// must return 201 — previously failed with invalid address type via GORM hooks.
+func (s *AddressTestSuite) TestCreateDefaultAddressSucceedsWhenUserAlreadyHasAddresses() {
+	payload := s.validCreatePayload(true)
+
+	w := s.customerClient.Post(s.T(), AddressAPIEndpoint, payload)
+	resp := helpers.AssertSuccessResponse(s.T(), w, http.StatusCreated)
+
+	data, ok := resp["data"].(map[string]any)
+	s.Require().True(ok)
+	addr, ok := data["address"].(map[string]any)
+	s.Require().True(ok)
+
+	s.Equal("HOME", addr["type"])
+	s.Equal(true, addr["isDefault"])
+	s.Equal("Rajkot", addr["city"])
+}
+
+// TestCreateAddressWithLatLngPersistsCoordinates
+func (s *AddressTestSuite) TestCreateAddressWithLatLngPersistsCoordinates() {
+	payload := s.validCreatePayload(true)
+	payload["type"] = "WORK"
+	payload["latitude"] = 22.3039
+	payload["longitude"] = 70.8022
+
+	w := s.customerClient.Post(s.T(), AddressAPIEndpoint, payload)
+	resp := helpers.AssertSuccessResponse(s.T(), w, http.StatusCreated)
+
+	data := resp["data"].(map[string]any)
+	addr := data["address"].(map[string]any)
+
+	s.Equal("WORK", addr["type"])
+	s.InDelta(22.3039, addr["latitude"].(float64), 0.0001)
+	s.InDelta(70.8022, addr["longitude"].(float64), 0.0001)
+	s.Equal(true, addr["isDefault"])
+}
+
+// TestSetDefaultAddressSucceeds
+func (s *AddressTestSuite) TestSetDefaultAddressSucceeds() {
+	payload := s.validCreatePayload(false)
+	payload["type"] = "WORK"
+	payload["address"] = "Non-default office address for set-default test"
+
+	w := s.customerClient.Post(s.T(), AddressAPIEndpoint, payload)
+	resp := helpers.AssertSuccessResponse(s.T(), w, http.StatusCreated)
+	addr := resp["data"].(map[string]any)["address"].(map[string]any)
+	addressID := uint(addr["id"].(float64))
+	// isDefault=false is omitted from JSON (omitempty) — ensure it is not true
+	s.NotEqual(true, addr["isDefault"])
+
+	w = s.customerClient.Patch(
+		s.T(),
+		fmt.Sprintf("%s/%d/default", AddressAPIEndpoint, addressID),
+		map[string]any{},
+	)
+	resp = helpers.AssertSuccessResponse(s.T(), w, http.StatusOK)
+	updated := resp["data"].(map[string]any)["address"].(map[string]any)
+	s.Equal(true, updated["isDefault"])
+	s.Equal(float64(addressID), updated["id"])
+}
+
+// TestUpdateAddressAsDefaultSucceeds
+func (s *AddressTestSuite) TestUpdateAddressAsDefaultSucceeds() {
+	payload := s.validCreatePayload(false)
+	payload["type"] = "HOME"
+	payload["address"] = "Address to update as default later"
+
+	w := s.customerClient.Post(s.T(), AddressAPIEndpoint, payload)
+	resp := helpers.AssertSuccessResponse(s.T(), w, http.StatusCreated)
+	addr := resp["data"].(map[string]any)["address"].(map[string]any)
+	addressID := uint(addr["id"].(float64))
+
+	isDefault := true
+	updatePayload := map[string]any{
+		"isDefault": isDefault,
+		"city":      "Ahmedabad",
+	}
+
+	w = s.customerClient.Put(
+		s.T(),
+		fmt.Sprintf("%s/%d", AddressAPIEndpoint, addressID),
+		updatePayload,
+	)
+	resp = helpers.AssertSuccessResponse(s.T(), w, http.StatusOK)
+	updated := resp["data"].(map[string]any)["address"].(map[string]any)
+	s.Equal(true, updated["isDefault"])
+	s.Equal("Ahmedabad", updated["city"])
+	s.Equal("HOME", updated["type"])
+}

--- a/user/repository/address_repository.go
+++ b/user/repository/address_repository.go
@@ -39,9 +39,13 @@ func (r *AddressRepositoryImpl) Create(ctx context.Context, address *entity.Addr
 	if count == 0 || address.IsDefault {
 		// If this is the first address or marked as default
 		tx := db.DB(ctx).Begin()
-		// Reset all existing addresses to non-default if this one is default
+		// Reset all existing addresses to non-default if this one is default.
+		// Use UpdateColumn to skip Address BeforeSave/BeforeUpdate hooks that
+		// validate Type on an empty model (would fail with invalid address type).
 		if address.IsDefault {
-			if err := tx.Model(&entity.Address{}).Where("user_id = ?", address.UserID).Update("is_default", false).Error; err != nil {
+			if err := tx.Model(&entity.Address{}).
+				Where("user_id = ?", address.UserID).
+				UpdateColumn("is_default", false).Error; err != nil {
 				tx.Rollback()
 				return err
 			}
@@ -98,11 +102,11 @@ func (r *AddressRepositoryImpl) FindByUserID(
 func (r *AddressRepositoryImpl) Update(ctx context.Context, address *entity.Address) error {
 	tx := db.DB(ctx).Begin()
 
-	// If setting as default, reset other addresses
+	// If setting as default, reset other addresses (skip hooks — empty model).
 	if address.IsDefault {
 		if err := tx.Model(&entity.Address{}).
 			Where("user_id = ? AND id != ?", address.UserID, address.ID).
-			Update("is_default", false).Error; err != nil {
+			UpdateColumn("is_default", false).Error; err != nil {
 			tx.Rollback()
 			return err
 		}
@@ -161,8 +165,10 @@ func (r *AddressRepositoryImpl) Delete(ctx context.Context, id uint, userID uint
 func (r *AddressRepositoryImpl) SetDefault(ctx context.Context, id uint, userID uint) error {
 	tx := db.DB(ctx).Begin()
 
-	// Reset all addresses to non-default
-	if err := tx.Model(&entity.Address{}).Where("user_id = ?", userID).Update("is_default", false).Error; err != nil {
+	// Reset all addresses to non-default (skip hooks — empty model).
+	if err := tx.Model(&entity.Address{}).
+		Where("user_id = ?", userID).
+		UpdateColumn("is_default", false).Error; err != nil {
 		tx.Rollback()
 		return err
 	}


### PR DESCRIPTION
Return wishlistItemId and wishlistId on product and variant responses so clients can remove items without extra lookups. Restructure wishlist detail to paginated items with per-item metadata and full product data. Resolve product IDs to default variants when adding wishlist items. Fix cross-seller media loading in product queries.

Also fix address default-flag updates to skip GORM hooks, allow X-Device-ID in CORS, and add address integration tests.